### PR TITLE
feat: Add axios retry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "^1.4.0",
         "axios-auth-refresh": "^3.3.6",
+        "axios-retry": "^4.5.0",
         "form-data": "^4.0.0",
         "tslib": "^2.5.0"
       },
@@ -265,6 +266,18 @@
       "license": "MIT",
       "peerDependencies": {
         "axios": ">= 0.18 < 0.19.0 || >= 0.19.1"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
+      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
       }
     },
     "node_modules/balanced-match": {
@@ -831,6 +844,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "axios": "^1.4.0",
     "axios-auth-refresh": "^3.3.6",
+    "axios-retry": "^4.5.0",
     "form-data": "^4.0.0",
     "tslib": "^2.5.0"
   },

--- a/src/api/http-client.ts
+++ b/src/api/http-client.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, HeadersDefaults, ResponseType } from "axios";
 import FormData from "form-data";
 import { SecurityDataFilter } from "../types/SecurityDataFilter";
+import { IAxiosRetryConfig } from "axios-retry";
 
 export type QueryParamsType = Record<string | number, any>;
 
@@ -27,6 +28,7 @@ export interface ApiConfig extends Omit<AxiosRequestConfig, "data" | "cancelToke
   securityWorker?: (params: SecurityDataFilter) => Promise<AxiosRequestConfig | void> | AxiosRequestConfig | void;
   secure?: boolean;
   format?: ResponseType;
+  axiosRetryConfig?: IAxiosRetryConfig
 }
 
 export enum ContentType {


### PR DESCRIPTION
This PR Adds axios retry to etsy-ts. The motivation behind this is to automatically retry 500/network errors. It adds a new `enableAxiosRetry` field which defaults to false(keeping backwards compatibility). It also allows an option to configure axios retry.